### PR TITLE
37 automatic copyright check and other improvements

### DIFF
--- a/src/main/java/com/greenfiling/smclient/internal/ApiClient.java
+++ b/src/main/java/com/greenfiling/smclient/internal/ApiClient.java
@@ -76,7 +76,7 @@ public abstract class ApiClient<BASE, READ, CREATE> {
   }
 
   public Index<READ> getNext(Index<READ> index) throws Exception {
-    throw new UnsupportedOperationException("The extending class did not implement the index method");
+    throw new UnsupportedOperationException("The extending class did not implement the getNext method");
   }
 
   public Index<READ> index() throws Exception {

--- a/src/main/java/com/greenfiling/smclient/model/LineItem.java
+++ b/src/main/java/com/greenfiling/smclient/model/LineItem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021 Green Filing, LLC
+ * Copyright 2021-2023 Green Filing, LLC
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/greenfiling/smclient/JsonDate_Manual.java
+++ b/src/test/java/com/greenfiling/smclient/JsonDate_Manual.java
@@ -23,8 +23,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Date;
 
-import org.junit.Test;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
@@ -60,7 +58,7 @@ public class JsonDate_Manual {
     }
   }
 
-  @Test
+  // @Test
   // I think this was verifying the change in name policy and converting dates, but I'm not sure this is something to make a unit test
   // or leave as manual
   public void testDate_From() throws Exception {

--- a/src/test/java/com/greenfiling/smclient/TestHelper.java
+++ b/src/test/java/com/greenfiling/smclient/TestHelper.java
@@ -95,6 +95,13 @@ public class TestHelper {
     System.out.println(String.format(template, args));
   }
 
+  public static void logE(String template, Object... args) {
+    if (QUIET_TESTS) {
+      return;
+    }
+    System.err.println(String.format(template, args));
+  }
+
   private static String getProperty(String string) {
     if (properties == null) {
       properties = loadProperties();

--- a/src/test/java/projecthealth/StandardContents_UnitTest.java
+++ b/src/test/java/projecthealth/StandardContents_UnitTest.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2023 Green Filing, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package projecthealth;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.net.URL;
+
+import org.junit.Test;
+
+import com.greenfiling.smclient.TestHelper;
+
+public class StandardContents_UnitTest {
+
+  // Run the find-copyright-issues.pl script and fail the test if it exits with a non-zero status.
+  // Any output from the script will be written to stderr for evaluation on the console
+  @Test
+  public void testCheckForAccurateCopyright() throws Exception {
+    URL script = TestHelper.class.getResource("/bin/find-copyright-issues.pl");
+    assertNotNull(script);
+
+    File scriptFile = new File(script.toURI());
+    assertNotNull(scriptFile);
+    scriptFile.setExecutable(true, true);
+
+    Process process = Runtime.getRuntime().exec(script.getPath());
+    assertNotNull(process);
+    BufferedReader reader = new BufferedReader(new InputStreamReader(process.getErrorStream()));
+    assertNotNull(reader);
+    String s;
+    while ((s = reader.readLine()) != null) {
+      TestHelper.logE("copyright errors: %s", s);
+    }
+
+    process.waitFor();
+    int exitStatus = process.exitValue();
+
+    assertTrue("copyright checker ran cleanly", exitStatus == 0);
+  }
+}

--- a/src/test/resources/bin/find-copyright-issues.pl
+++ b/src/test/resources/bin/find-copyright-issues.pl
@@ -18,7 +18,7 @@ use strict;
 use File::Find;
 use FindBin qw($Bin);
 
-my $findsrc = "$Bin/..";
+my $findsrc = "$Bin/../../..";
 
 my $fileToYearMap = getFileVcsModTime();
 

--- a/src/test/resources/bin/find-copyright-issues.pl
+++ b/src/test/resources/bin/find-copyright-issues.pl
@@ -19,12 +19,14 @@ use File::Find;
 use FindBin qw($Bin);
 
 my $findsrc = "$Bin/../../..";
+$findsrc = "$Bin/../../../src" if ($findsrc =~ m|/target/|);
 
 my $fileToYearMap = getFileVcsModTime($findsrc);
 
+our $foundErrorCount = 0;
 find(\&wanted, $findsrc);
 
-exit;
+exit $foundErrorCount;
 
 sub wanted {
 	return 0 if ($File::Find::name !~ /\.(java|pl)/);
@@ -85,6 +87,7 @@ sub wanted {
 sub error {
 	my $msg = shift;
 	print STDERR "$msg\n";
+	$main::foundErrorCount++;
 }
 
 # pieced together from multiple answers from https://serverfault.com/questions/401437/how-to-retrieve-the-last-modification-date-of-all-files-in-a-git-repository


### PR DESCRIPTION
Elena, thought you might appreciate seeing what the other side of the review process looked like.

Hopefully the logs for the commits explain what's going on here, but the main goal was to run find-copyright-issues.pl automatically in junit/mvn test.

I would appreciate it if you ran this code on your local machine as part of this review.  Specifically I want to test that the script works in other environments.  To the best of my knowledge I wrote it only using standard libraries, but it's worth checking.  The easiest way to check this, pre-merge, is to add my repo jetmore/servemanager-client) as a second remote and then check out jetmore/37-automatic-copyright-check-and-other-improvements.  At that point you can run unit tests with `mvn clean test`.  Goal one is that the script itself runs. Goal two is that the test should run clean.

I added this test because I forgot to tell you about adding copyright and license statements on the top of every *.java file.  I was going to just tell you to do it when I realized I forgot to update the copyright year in LineItem.java, and if I can't remember to do it, I should't expect others to do it also.

So all that said, I suggest the following code review for maximum benefit, and also to give you an excuse to play with stuff like alternate remotes, temporary branches, and merging
* do a visual review of the code
* add a new remote to your private repo (the one cloned on your laptop) of jetmore/servemanager-client. Suggest calling this new remote "john".
* check out john/37-automatic-copyright-check-and-other-improvements in your local enviroment
* make sure you can run `mvn clean test`.  There shouldn't be any errors, but you can simulate some by removing copyright notices from a file or changing the copyright year to something wroing
* make a new branch off of 37-automatic-copyright-check-and-other-improvements called tmp-test-copyright or something
* merge your local main (because they have your changes for SupplierCost interface) into tmp-test-copyright and make sure tmp-test-copyright is checked out
* run `mvn clean test`, expect the test to fail and the console to list all of the files you added  for Supplier cost

You don't actually have to fix the errors shown in that merge branch.  Instead I would delete that tmp-test-copyright branch, merge this PR, pull the greenfiling/main changes into your eosergi/main , then run `mvn clean test` from that branch and fix it there, where the changes will be automatically included in the existing PR, when pushed

Sorry if the above is overly explicit.  Trying to give you meat to google if there's an unfamiliar topic.  Let's talk about your general experience of this process, and obviously also if you have any problems or questions