### PR TITLE
Download files through api

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -1,4 +1,12 @@
 #######################
+## 1.0.6
+## 2023-04-13
+
+  * Support file downloads that require API authentication
+  * Broad testing improvements (#25, #38, #2)
+  * Minor bug fixes
+
+#######################
 ## 1.0.5
 ## 2023-02-13
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Installing
 <dependency>
     <groupId>com.greenfiling.smclient</groupId>
     <artifactId>servemanager-client</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,9 @@ Example of how this would be set in live code:
 
 #### Downloading Files
 
-Every client class offers a `getFile()` method for downloading arbitrary files.  This action has nothing to do with the API, but is provided as a convenience since it is useful for downloading documents referenced by the API.
+The ApiHandle class offers two methods for downloading files from URLs, `doGetFile()` and `doGetFileApi()`.  Every client class also inherits convenience interfaces to these methods, `getFile()` and `getFileApi()`.  These two methods are equivalent; `apiHandle.doGetFile(url, file);` and `jobClient.getFile(url, file);` are identical.
+
+The `doGetFile()` method is for downloading arbitrary files.  This action has nothing to do with the ServeManager API, but is provided as a convenience since it is useful for downloading documents referenced by the API.
 
 ```java
 JobClient client = new JobClient(apiHandle);
@@ -257,6 +259,18 @@ String localPath = System.getProperty("java.io.tmpdir") + "/" + doc.getUpload().
 String url = doc.getUpload().getLinks().getDownloadUrl();
 
 client.getFile(url, localPath);
+System.out.println("Downloaded from " + url);
+System.out.println("Downloaded to " + localPath);
+```
+
+The `doGetFileApi()` method is for downloading files that require API authentication to access.  It behaves identically, it just ensures that API credentials are added to the call.  Notably, while most objects present a URL that does not require authentication, the Document object (which is used to return affidavits related to the job) uses URLs which present as part of the API and require authentication.
+
+```java
+Document affidavit = job.getDocuments().get(0);
+String url = affidavit.getPdfDownloadUrl();
+String localPath = System.getProperty("java.io.tmpdir") + "/" + affidavit.getId().toString() + ".pdf";
+
+client.getFileApi(url, localPath);
 System.out.println("Downloaded from " + url);
 System.out.println("Downloaded to " + localPath);
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.greenfiling.smclient</groupId>
   <artifactId>servemanager-client</artifactId>
-  <version>1.0.6-SNAPSHOT</version>
+  <version>1.0.6</version>
   <name>ServeManager Api Client</name>
   <description>Java implementation of client for ServeManager API (https://www.servemanager.com/)</description>
   <url>https://www.github.com/greenfiling/servemanager-client</url>

--- a/src/main/java/com/greenfiling/smclient/internal/ApiClient.java
+++ b/src/main/java/com/greenfiling/smclient/internal/ApiClient.java
@@ -61,8 +61,32 @@ public abstract class ApiClient<BASE, READ, CREATE> {
     throw new UnsupportedOperationException("The extending class did not implement the create method");
   }
 
-  public void getFile(String Url, String filePath) throws Exception {
-    getHandle().doGetFile(Url, filePath);
+  /**
+   * Download an arbitrary URL as a file and save it to filePath
+   * 
+   * @param url
+   *          URL to download file from
+   * @param filePath
+   *          File on disk to save contents of download to
+   * @throws Exception
+   *           thrown if file cannot be downloaded for any reason
+   */
+  public void getFile(String url, String filePath) throws Exception {
+    getHandle().doGetFile(url, filePath);
+  }
+
+  /**
+   * Download a URL as a file with api authentication and save it to filePath
+   * 
+   * @param url
+   *          URL to download file from (assumed to be protected by ServeManager API authentication)
+   * @param filePath
+   *          File on disk to save contents of download to
+   * @throws Exception
+   *           thrown if file cannot be downloaded for any reason
+   */
+  public void getFileApi(String url, String filePath) throws Exception {
+    getHandle().doGetFileApi(url, filePath);
   }
 
   public Index<READ> getNext(Index<READ> index) throws Exception {

--- a/src/test/java/com/greenfiling/smclient/JobClient_IntegrationTest.java
+++ b/src/test/java/com/greenfiling/smclient/JobClient_IntegrationTest.java
@@ -369,10 +369,10 @@ public class JobClient_IntegrationTest {
     Integer jobId = createResponse.getData().getId();
 
     Show<Job> response = client.show(jobId);
-    assertThat(createResponse, not(equalTo(null)));
-    assertThat(createResponse.getData(), not(equalTo(null)));
-    assertThat(createResponse.getData().getLinks(), not(equalTo(null)));
-    assertThat(createResponse.getData().getId(), equalTo(jobId));
+    assertThat(response, not(equalTo(null)));
+    assertThat(response.getData(), not(equalTo(null)));
+    assertThat(response.getData().getLinks(), not(equalTo(null)));
+    assertThat(response.getData().getId(), equalTo(jobId));
 
     Links links = response.getData().getLinks();
     log("links.self = %s", links.getSelf());

--- a/src/test/java/com/greenfiling/smclient/manual/ApiHandle_Manual.java
+++ b/src/test/java/com/greenfiling/smclient/manual/ApiHandle_Manual.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 import com.greenfiling.smclient.ApiHandle;
 import com.greenfiling.smclient.JobClient;
+import com.greenfiling.smclient.model.Document;
 import com.greenfiling.smclient.model.Job;
 import com.greenfiling.smclient.model.JobSubmit;
 import com.greenfiling.smclient.model.Links;
@@ -110,4 +111,64 @@ public class ApiHandle_Manual {
     assertThat("Downloaded file is not empty", (int) file.length(), greaterThan(0));
   }
 
+  // this tests downloading an affidavit from the API, which requires API auth (though as currently implemented it then redirects to AWS for
+  // download). Since you can't programmatically create an affidavit, you have to have a pre-existing job to test it with. As such, this test
+  // can't be run automatically.
+  // @Test
+  public void testGetFileApi() throws Exception {
+    Integer jobId = 12141464; // this is a servemanager job that has at least one affidavit associated with it
+
+    Show<Job> response = client.show(jobId);
+    assertThat(response, not(equalTo(null)));
+    assertThat(response.getData(), not(equalTo(null)));
+    assertThat(response.getData().getLinks(), not(equalTo(null)));
+    assertThat(response.getData().getId(), equalTo(jobId));
+
+    Job job = response.getData();
+    assertThat(job.getDocuments(), not(equalTo(null)));
+    assertThat(job.getDocuments().size(), not(equalTo(0)));
+
+    Document d = job.getDocuments().get(0);
+    assertThat(d, not(equalTo(null)));
+
+    String smUrl = d.getPdfDownloadUrl();
+    String localPath = System.getProperty("java.io.tmpdir") + "/" + d.getId().toString() + ".pdf";
+    log("Downloading from %s", smUrl);
+
+    client.getFileApi(smUrl, localPath);
+    log("Downloaded to %s", localPath);
+    File file = new File(localPath);
+    assertThat("Downloaded file does not exist", file.exists(), equalTo(true));
+    assertThat("Downloaded file is not empty", (int) file.length(), greaterThan(0));
+
+  }
+
+  // @Test
+  public void testGetFile() throws Exception {
+    // Integer jobId = 12141464; // this is a servemanager job that has at least one affidavit associated with it
+    //
+    // Show<Job> response = client.show(jobId);
+    // assertThat(response, not(equalTo(null)));
+    // assertThat(response.getData(), not(equalTo(null)));
+    // assertThat(response.getData().getLinks(), not(equalTo(null)));
+    // assertThat(response.getData().getId(), equalTo(jobId));
+    //
+    // Job job = response.getData();
+    // assertThat(job.getDocuments(), not(equalTo(null)));
+    // assertThat(job.getDocuments().size(), not(equalTo(0)));
+    //
+    // Document d = job.getDocuments().get(0);
+    // assertThat(d, not(equalTo(null)));
+
+    String smUrl = "https://sm-attachments.s3.amazonaws.com/rahdakdrd7tviertlgye4d226mi7?response-content-disposition=attachment%3B%20filename%3D%22smbc-1681060021-5132-image-6888662134da85aae764088b798d56b0.png%22%3B%20filename%2A%3DUTF-8%27%27smbc-1681060021-5132-image-6888662134da85aae764088b798d56b0.png&response-content-type=image%2Fpng&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAZKFIACFP4R3MB2O4%2F20230410%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230410T151344Z&X-Amz-Expires=1800&X-Amz-SignedHeaders=host&X-Amz-Signature=5b34bd7fec17dabc19861d2975d6c4b61d8b850d97668d2b2677b7c2d2e358f4";
+    String localPath = System.getProperty("java.io.tmpdir") + "/" + "test" + ".pdf";
+    log("Downloading from %s", smUrl);
+
+    client.getFile(smUrl, localPath);
+    log("Downloaded to %s", localPath);
+    File file = new File(localPath);
+    assertThat("Downloaded file does not exist", file.exists(), equalTo(true));
+    assertThat("Downloaded file is not empty", (int) file.length(), greaterThan(0));
+
+  }
 }

--- a/src/test/java/com/greenfiling/smclient/manual/Playground.java
+++ b/src/test/java/com/greenfiling/smclient/manual/Playground.java
@@ -41,7 +41,10 @@ import com.greenfiling.smclient.ApiHandle;
 import com.greenfiling.smclient.JobClient;
 import com.greenfiling.smclient.model.Attachment;
 import com.greenfiling.smclient.model.Job;
+import com.greenfiling.smclient.model.JobSubmit;
 import com.greenfiling.smclient.model.Links;
+import com.greenfiling.smclient.model.exchange.Index;
+import com.greenfiling.smclient.model.exchange.JobFilter;
 import com.greenfiling.smclient.model.exchange.Show;
 import com.greenfiling.smclient.util.TestHelper;
 
@@ -94,6 +97,17 @@ public class Playground {
 
     apiHandle = TestHelper.getApiHandle();
     client = new JobClient(apiHandle);
+  }
+
+  // "custom" is in their API but I have no idea how to use it or why. This was a failed attempt to interact with it
+  @Test
+  public void testFoo() throws Exception {
+    ApiHandle apiHandle = TestHelper.getApiHandle();
+    JobClient client = new JobClient(apiHandle);
+
+    JobSubmit jobUpdate = new JobSubmit();
+    jobUpdate.setJobStatus("Pending Archive");
+    client.update(11749867, jobUpdate);
   }
 
   @Test
@@ -161,6 +175,43 @@ public class Playground {
     log("VALID_API_KEY: %s", TestHelper.VALID_API_KEY);
     log("VALID_FILE_1: %s", TestHelper.VALID_FILE_PATH_1);
     log("VALID_FILE_2: %s", TestHelper.VALID_FILE_PATH_2);
+  }
+
+  // This is a test demonstrating how different filter types relate to each other (and vs or)
+  @Test
+  public void testIndexJob_Filter_HappyPath() throws Exception {
+    ApiHandle apiHandle = TestHelper.getApiHandle();
+    JobClient client = new JobClient(apiHandle);
+
+    JobFilter filter = new JobFilter();
+    filter.getJobStatus().add("Pending Archive");
+    filter.setQ(", Type: service of process");
+
+    Index<Job> response = client.index(filter);
+    assertThat(response, not(equalTo(null)));
+    assertThat(response.getData(), not(equalTo(null)));
+    assertThat(response.getLinks(), not(equalTo(null)));
+
+    Links links = response.getLinks();
+    log("links.self = %s", links.getSelf());
+
+    for (Job j : response.getData()) {
+      System.out.println(String.format("%s / %s :: %s", j.getJobStatus(), j.getServiceStatus(), j.getClientJobNumber()));
+    }
+
+    filter.setQ(", Type: courtesy copy");
+    response = client.index(filter);
+    assertThat(response, not(equalTo(null)));
+    assertThat(response.getData(), not(equalTo(null)));
+    assertThat(response.getLinks(), not(equalTo(null)));
+
+    links = response.getLinks();
+    log("links.self = %s", links.getSelf());
+
+    for (Job j : response.getData()) {
+      log("%s / %s :: %s", j.getJobStatus(), j.getServiceStatus(), j.getClientJobNumber());
+    }
+
   }
 
   @Test


### PR DESCRIPTION
Downloading affidavits requires an authenticated hit against the API.  Add getFileApi() (analogous to existing getFile()) to support it