### PR TITLE
Feature/rm 6584 code formatting

### DIFF
--- a/src/test/java/com/greenfiling/smclient/suites/AllManual_Suite.java
+++ b/src/test/java/com/greenfiling/smclient/suites/AllManual_Suite.java
@@ -24,12 +24,12 @@ import com.greenfiling.smclient.manual.ApiHandle_Manual;
 
 @RunWith(Suite.class)
 
-//@formatter:off
+// @formatter:off
 @Suite.SuiteClasses({
   ApiHandle_Manual.class,
   JobClient_FlexUpload_Manual.class
 })
-//@formatter:on
+// @formatter:on
 
 public class AllManual_Suite {
 


### PR DESCRIPTION
Apply rules from https://greenfiling.atlassian.net/wiki/spaces/DEV/pages/1005977601/Coding+Style+Guide

Possibly incomplete list of issues fixed in these changes:
- There should be a single space between `//` and `@formatter`

See also greenfiling/GreenFiling#178