### PR TITLE
NOTICKET adding automatic adding to Github Project

### DIFF
--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -1,0 +1,16 @@
+---
+name: Add to Project
+run-name: 🚀 Adding ticket to PRs Project
+on:
+  pull_request:
+    types:
+      - opened
+jobs:
+   add-to-project:
+    name: Add pull request to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/greenfiling/projects/1/
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Adding automatic adding to the ALL PR's Project.

This automatically will run a [github action](https://github.com/marketplace/actions/add-to-github-projects) when a PR is opened, and will add the PR to the All PRs project.

In order to enable this I had to create a personal access token (PAT) to allow read access to repos & projects. This has been stored in Github Using the ADD_TO_PROJECT_PAT secret. See [here](https://github.com/organizations/greenfiling/settings/secrets/actions) for more
The issue

The documentation[fn:1] for this suggests that this can only be done per action with a limit to the number of repos you can add per org of 5. There is a github feature request for this[fn:2], but it looks like the best way to add this functionality.

[fn:1] https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/adding-items-automatically
[fn:2] https://github.com/marketplace/actions/add-to-github-projects
[fn:3] https://github.com/orgs/greenfiling/projects/1/workflows/13348487