### PR TITLE
RM-6499 update Job.mailingDate type

### DIFF
--- a/src/main/java/com/greenfiling/smclient/model/Job.java
+++ b/src/main/java/com/greenfiling/smclient/model/Job.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2021-2024 Green Filing, LLC
+ * Copyright 2021-2025 Green Filing, LLC
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package com.greenfiling.smclient.model;
 
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -38,7 +39,7 @@ public class Job extends JobBase {
   private Recipient recipient;
   private Integer dupedFromJobId;
   private ArrayList<Integer> dupedToJobIds;
-  private OffsetDateTime mailingDate;
+  private LocalDate mailingDate;
   private Integer mailedById;
   private String mailingLocation;
   private Boolean mailingRequired;
@@ -180,7 +181,7 @@ public class Job extends JobBase {
     return this.mailedById;
   }
 
-  public OffsetDateTime getMailingDate() {
+  public LocalDate getMailingDate() {
     return this.mailingDate;
   }
 
@@ -336,7 +337,7 @@ public class Job extends JobBase {
     this.mailedById = mailedById;
   }
 
-  public void setMailingDate(OffsetDateTime mailingDate) {
+  public void setMailingDate(LocalDate mailingDate) {
     this.mailingDate = mailingDate;
   }
 

--- a/src/test/java/com/greenfiling/smclient/model/exchange/Payload_UnitTest.java
+++ b/src/test/java/com/greenfiling/smclient/model/exchange/Payload_UnitTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Green Filing, LLC
+ * Copyright 2024-2025 Green Filing, LLC
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.time.OffsetDateTime;
+import java.time.LocalDate;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -71,7 +71,7 @@ public class Payload_UnitTest {
 
     assertEquals(false, aJob.getAssignedByCollaboratingServer());
     assertEquals(Integer.valueOf(99990), aJob.getMailedById());
-    assertEquals(OffsetDateTime.parse("2023-07-20T16:11:19-06:00"), aJob.getMailingDate());
+    assertEquals(LocalDate.parse("2023-07-20"), aJob.getMailingDate());
     assertEquals("Test description", aJob.getMailingLocation());
     assertEquals(false, aJob.getMailingRequired());
 

--- a/src/test/resources/Samples/PayLoad.json
+++ b/src/test/resources/Samples/PayLoad.json
@@ -67,7 +67,7 @@
       "duped_from_job_id": 99997,
       "duped_to_job_ids": [99999, 99998],
       "job_type_id": null,
-      "mailing_date": "2023-07-20T16:11:19-06:00",
+      "mailing_date": "2023-07-20",
       "mailed_by_id": 99990,
       "mailing_location": "Test description",
       "mailing_required": false,


### PR DESCRIPTION
Previous type was incorrect and failed to parse any SM job info if any mailing_date fields were set